### PR TITLE
Fix: Actor verticle start promise management

### DIFF
--- a/src/main/java/actors/Actor.java
+++ b/src/main/java/actors/Actor.java
@@ -49,21 +49,21 @@ public class Actor<I> extends AbstractVerticle
     {
       messageConsumer = vertx.eventBus()
                              .consumer(address,
-                                       m ->
+                                       message ->
                                        {
                                          try
                                          {
-                                           this.consumer.accept((Message<I>) m);
+                                           this.consumer.accept((Message<I>) message);
                                          }
                                          catch (Exception e)
                                          {
-                                           m.fail(RECIPIENT_FAILURE.toInt(),
+                                           message.fail(RECIPIENT_FAILURE.toInt(),
                                                   e.toString()+" @ "+e.getStackTrace()[0]
                                                  );
                                          }
                                        }
                                       );
-      promise.complete();
+        messageConsumer.completionHandler(promise);
     }
 
     catch (Exception e)

--- a/src/main/java/actors/ActorRef.java
+++ b/src/main/java/actors/ActorRef.java
@@ -86,10 +86,10 @@ public class ActorRef<I, O>
   public Consumer<I> tell(final DeliveryOptions options)
   {
     requireNonNull(options);
-    return body -> vertx.eventBus().<I>request(address,
+    return body -> vertx.eventBus().send(address,
                                                body,
                                                options
-                                              ).map(Message::body);
+                                              );
   }
 
   /**

--- a/src/main/java/actors/ActorsModule.java
+++ b/src/main/java/actors/ActorsModule.java
@@ -37,7 +37,7 @@ public abstract class ActorsModule extends AbstractVerticle
 
     try
     {
-      actors = new Actors(Objects.requireNonNull(vertx));
+      actors = new Actors(Objects.requireNonNull(getVertx()));
       registerMessageCodecs(vertx);
       CompositeFuture.all(deployActors())
                      .onComplete(result -> failIfErrorOrInitModule(start,
@@ -59,21 +59,21 @@ public abstract class ActorsModule extends AbstractVerticle
   {
   }
 
-  private void failIfErrorOrInitModule(final Promise<Void> start,
-                                       final AsyncResult<CompositeFuture> result
-                                      )
-  {
-    if (result.failed()) start.fail(result.cause());
-    try
+    private void failIfErrorOrInitModule(final Promise<Void> start,
+                                         final AsyncResult<CompositeFuture> result
+                                        )
     {
-      defineActors(result.result().list());
-      start.complete();
+        if (result.failed()) {
+            start.fail(result.cause());
+        } else {
+            try {
+                defineActors(result.result().list());
+                start.complete();
+            } catch (Exception e) {
+                start.fail(e);
+            }
+        }
     }
-    catch (Exception e)
-    {
-      start.fail(e);
-    }
-  }
 
   /**
    Call this method from the {@link #defineActors(List)} method to cast every object of the list into


### PR DESCRIPTION
Se cambia el arranque de los verticles para gestionar correctamente el premise del Start y se cambia el método del event bus utilizando en la llamada tell